### PR TITLE
samba36: fix build (issue #5574)

### DIFF
--- a/package/network/services/samba36/Makefile
+++ b/package/network/services/samba36/Makefile
@@ -101,6 +101,7 @@ CONFIGURE_ARGS += \
 	--prefix=/ \
 	--disable-avahi \
 	--disable-cups \
+	--disable-external-libtalloc \
 	--disable-pie \
 	--disable-relro \
 	--disable-static \


### PR DESCRIPTION
Maintainer: Felix Fietkau <nbd@nbd.name>
Compile tested: ramips, Xiaomi Router 3G,
138c76332b7e39b3c4e3018e7792e74645ab0c7a
Run tested: will update in few hours

Description:
As indicated in https://github.com/openwrt/packages/issues/5574 samba fails
to build with linker error due to lack of talloc_* functions.

According to Makefile it is compiled with "--without-libtalloc" option.
Running ./configure --help shows that there is another option connected to
libtalloc: --enable/disable-external-libtalloc.
Adding this option fixes build.

Signed-off-by: Jakub Tymejczyk jakub@tymejczyk.pl
